### PR TITLE
Undo temporary policy that disallows changes to collection.xml

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+8.0.0
+-----
+
+- Undo temporary policy to disallow changes to collection.xml files
+
 7.3.0
 -----
 

--- a/press/exceptions.py
+++ b/press/exceptions.py
@@ -20,9 +20,3 @@ class Unchanged(Exception):
     """Raised when checked out version is older than published version"""
     def __init__(self, model):
         self.model = model
-
-
-class CollectionChanged(Exception):
-    """Raised when checked out version is older than published version"""
-    def __init__(self, collection):
-        self.collection = collection

--- a/press/legacy_publishing/litezip.py
+++ b/press/legacy_publishing/litezip.py
@@ -16,7 +16,7 @@ __all__ = (
 )
 
 
-def publish_litezip(struct, submission, db_conn, coll_changes_allowed=True):
+def publish_litezip(struct, submission, db_conn):
     """Publish the contents of a litezip structured set of data.
 
     :param struct: a litezip struct from (probably from
@@ -33,13 +33,6 @@ def publish_litezip(struct, submission, db_conn, coll_changes_allowed=True):
         collection = [x for x in struct if isinstance(x, Collection)][0]
     except IndexError:  # pragma: no cover
         raise NotImplementedError('litezip without collection')
-
-    try:
-        module = [x for x in struct if isinstance(x, Module)][0]
-        metadata = parse_module_metadata(module)
-        publish_legacy_book(collection, metadata, submission, db_conn)
-    except IndexError:  # pragma: no cover
-        pass  # if no modules, no problem.
 
     id_map = {}  # pragma: no cover
 
@@ -66,7 +59,7 @@ def publish_litezip(struct, submission, db_conn, coll_changes_allowed=True):
                 legacy_version = convert_version_to_legacy_version(version)
                 elm.attrib[version_attrib_name] = legacy_version
         except Unchanged:
-            pass
+            pass  # only publish content that has changed.
 
     any_changes = id_map != {}
     if any_changes:
@@ -78,7 +71,7 @@ def publish_litezip(struct, submission, db_conn, coll_changes_allowed=True):
     metadata = parse_collection_metadata(collection)
     old_id = collection.id
     (id, version), ident = publish_legacy_book(
-        collection, metadata, submission, db_conn, changed=any_changes)
+        collection, metadata, submission, db_conn)
     id_map[old_id] = (id, version)
 
     return id_map

--- a/press/views/legacy_publishing.py
+++ b/press/views/legacy_publishing.py
@@ -5,7 +5,7 @@ from litezip import parse_litezip, validate_litezip
 from pyramid.view import view_config
 
 from .. import events
-from ..exceptions import StaleVersion, Unchanged, CollectionChanged
+from ..exceptions import StaleVersion, Unchanged
 from ..legacy_publishing import publish_litezip
 from ..publishing import (
     discover_content_dir,
@@ -85,17 +85,8 @@ def publish(request):
              }
         ]}
     except Unchanged:
-        request.response.status = 204  # maybe?  # TODO: change neb as well.
+        request.response.status = 202  # maybe?  # TODO: change neb as well.
         return None
-    except CollectionChanged as err:
-        request.response.status = 400
-        return {'messages': [
-            {'id': 4,
-             'message': 'collection changed',
-             'item': err.collection.id,
-             'error': 'modifying a collection is temporarily disallowed'
-             }
-        ]}
 
     finish_event = events.LegacyPublicationFinished(
         id_mapping.values(),

--- a/tests/functional/legacy_publishing/test_collection.py
+++ b/tests/functional/legacy_publishing/test_collection.py
@@ -1,4 +1,8 @@
-from press.exceptions import CollectionChanged
+from datetime import timedelta
+from dateutil.parser import parse as parse_date
+from litezip.main import COLLECTION_NSMAP
+from sqlalchemy.sql import text
+
 from press.legacy_publishing.collection import (
     publish_legacy_book,
 )
@@ -6,43 +10,16 @@ from press.parsers import (
     parse_collection_metadata,
 )
 
-
-def test_prevent_any_changes_to_collections(
-        content_util, persist_util, app, db_engines, db_tables):
-    # Insert initial collection and modules.
-    resources = list([content_util.gen_resource() for x in range(0, 2)])
-    collection, tree, modules = content_util.gen_collection(
-        resources=resources
-    )
-    modules = list([persist_util.insert_module(m) for m in modules])
-    collection, tree, modules = content_util.rebuild_collection(collection,
-                                                                tree)
-    collection = persist_util.insert_collection(collection)
-    metadata = parse_collection_metadata(collection)
-
-    # Insert a new module ...
-    new_module = content_util.gen_module()
-    new_module = persist_util.insert_module(new_module)
-    # ... remove second element from the tree ...
-    tree.pop(1)
-    # ... and append the new module to the tree.
-    tree.append(content_util.make_tree_node_from(new_module))
-    collection, _, _ = content_util.rebuild_collection(collection, tree)
-
-    try:
-        with db_engines['common'].begin() as conn:
-            (id, version), ident = publish_legacy_book(
-                collection,
-                metadata,
-                ('user1', 'test publish',),
-                conn,
-            )
-    except CollectionChanged as err:
-        # should fail because the collection changed.
-        assert err.collection.id == collection.id
+from tests.conftest import GOOGLE_ANALYTICS_CODE
+from tests.helpers import (
+    compare_legacy_tree_similarity,
+    element_tree_from_model,
+)
+from tests.random_image import (
+    generate_random_image_by_size,
+)
 
 
-"""FIXME: uncomment.
 def test_publish_revision_base_case(
         content_util, persist_util, app, db_engines, db_tables):
     # Insert initial collection and modules.
@@ -150,6 +127,7 @@ def test_publish_revision_base_case(
     inserted_tree = db_engines['common'].execute(stmt).fetchone()[0]
     compare_legacy_tree_similarity(inserted_tree['contents'], tree)
 
+
 def test_publish_revision_with_new_abstract(
         content_util, persist_util, app, db_engines, db_tables):
     # Insert initial collection and modules.
@@ -200,6 +178,7 @@ def test_publish_revision_with_new_abstract(
     )
     result = db_engines['common'].execute(stmt).fetchone()
     assert result.abstractid != control_metadata.abstractid
+
 
 # https://github.com/Connexions/cnx-press/issues/148
 def test_publish_revision_with_created_value_changed(
@@ -258,6 +237,7 @@ def test_publish_revision_with_created_value_changed(
     result = db_engines['common'].execute(stmt).fetchone()
     assert result.created == control_metadata.created
     assert result.created != changed_created
+
 
 def test_publish_derived(
         content_util, persist_util, app, db_engines, db_tables):
@@ -489,4 +469,3 @@ def test_publish_revision_that_overwrites_existing_resources(
     assert files[new_book_cover.filename].sha1 == new_book_cover.sha1
     assert files[new_book_cover.filename].file == \
         new_book_cover.data.read_bytes()
-"""

--- a/tests/functional/legacy_publishing/test_litezip.py
+++ b/tests/functional/legacy_publishing/test_litezip.py
@@ -1,6 +1,9 @@
-from press.exceptions import CollectionChanged
+from sqlalchemy.sql import text
 from press.legacy_publishing.litezip import (
     publish_litezip,
+)
+from tests.helpers import (
+    compare_legacy_tree_similarity,
 )
 
 
@@ -24,17 +27,6 @@ def test_publish_litezip(
                                                                 tree)
     struct = tuple([collection, new_module])
 
-    try:
-        with db_engines['common'].begin() as conn:
-            publish_litezip(
-                struct,
-                ('user1', 'test publish',),
-                conn,
-            )
-    except CollectionChanged as err:
-        assert err.collection.id == collection.id
-
-    """FIXME: uncomment.
     with db_engines['common'].begin() as conn:
         id_map = publish_litezip(
             struct,
@@ -61,4 +53,3 @@ def test_publish_litezip(
         .bindparams(moduleid=collection.id, major_version=1, minor_version=2))
     inserted_tree = db_engines['common'].execute(stmt).fetchone()[0]
     compare_legacy_tree_similarity(inserted_tree['contents'], tree)
-    """

--- a/tests/functional/views/test_legacy_publishing.py
+++ b/tests/functional/views/test_legacy_publishing.py
@@ -215,9 +215,7 @@ def test_publishing_revision_litezip(
         upload_files=file_data,
         expect_errors=True,
     )
-    assert resp.status_code == 400
-
-    """FIXME: uncomment this block of code.
+    assert resp.status_code == 200
 
     # Check resulting data. (id mapping and urls)
     t = db_tables
@@ -248,7 +246,6 @@ def test_publishing_revision_litezip(
     assert result.version == version
     assert result.submitter == publisher
     assert result.submitlog == message
-    """
 
 
 def test_publishing_overwrite_module_litezip(
@@ -290,9 +287,7 @@ def test_publishing_overwrite_module_litezip(
         upload_files=file_data,
         expect_errors=True,
     )
-    # FIXME: uncomment.
-    # assert resp.status_code == 200
-    assert resp.status_code == 400
+    assert resp.status_code == 200
 
     # Try to submit the publication again (version 1.1)
     with file.open('rb') as fb:
@@ -304,16 +299,18 @@ def test_publishing_overwrite_module_litezip(
         upload_files=file_data,
         expect_errors=True,
     )
-    assert resp.status_code == 400
-    expected_msgs = [
-        {
-            "id": 4,
-            "message": "collection changed",
-            "item": collection.id,
-            "error": 'modifying a collection is temporarily disallowed'
-        }
-    ]
-    assert resp.json['messages'] == expected_msgs
+    # FIXME: expect stale version error
+#    assert resp.status_code == 400
+#    expected_msgs = [
+#        {
+#            "id": 4,
+#            "message": "collection changed",
+#            "item": collection.id,
+#            "error": 'modifying a collection is temporarily disallowed'
+#        }
+#    ]
+#    assert resp.json['messages'] == expected_msgs
+    assert resp.status_code == 200
 
 
 def test_publishing_overwrite_collection_litezip(
@@ -348,9 +345,7 @@ def test_publishing_overwrite_collection_litezip(
         upload_files=file_data,
         expect_errors=True,
     )
-    # FIXME: uncomment.
-    # assert resp.status_code == 204
-    assert resp.status_code == 400  # no changes to collection.xml
+    assert resp.status_code == 200
 
     # Submit a publication, again.
     # Note that this increases the version for new_modules[0] to 1.2
@@ -363,9 +358,7 @@ def test_publishing_overwrite_collection_litezip(
         upload_files=file_data,
         expect_errors=True,
     )
-    # FIXME: uncomment.
-    # assert resp.status_code == 204
-    assert resp.status_code == 400  # no changes to collection.xml
+    assert resp.status_code == 200
 
 
 def test_publishing_no_changes(


### PR DESCRIPTION
The temporary policy was added because of a corner case that prevented
us from making Press only publish changed content.  Since there will be
a fix for this, we can remove the temporary policy.

----

Part 1/3 of #190