### PR TITLE
Add a SAX-based collection.xml parser

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -6,6 +6,7 @@ Change Log
 -----
 
 - Undo temporary policy to disallow changes to collection.xml files
+- Create a collection xml parser
 
 7.3.0
 -----

--- a/press/models/__init__.py
+++ b/press/models/__init__.py
@@ -1,11 +1,12 @@
 from collections import namedtuple
 
+from .press_element import PressElement
 
 __all__ = (
     'CollectionMetadata',
     'ModuleMetadata',
+    'PressElement',
 )
-
 
 CollectionMetadata = namedtuple(
     'CollectionMetadata',

--- a/press/models/press_element.py
+++ b/press/models/press_element.py
@@ -1,0 +1,142 @@
+class PressElement:
+    """Represents a collxml element parsed from a Collection XML file.
+    """
+    def __init__(self, tag, attrs=None, text='', tail=''):
+        self.tag = tag  # TODO: prevent whitespace in tag name / VALIDATE tag
+        self.text = text
+        self.tail = tail
+        self.attrs = (attrs and attrs.copy()) or {}
+        self.children = []
+        self.parent = None
+
+    """Make it hashable so that we can convert the tree to a set and then use
+    set operations.
+    """
+    def __hash__(self):
+        module_id = self.attrs.get('document', '')
+        return hash((self.tag, self.text, self.tail, module_id))
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    """Represent a tag as it would appear in the source collxml file,
+    with the exception that this also includes the trailing text (``tail``)
+    prepended with ``...`` (ellipsis).
+    """
+    def __repr__(self):
+        text = self.text or ''
+        tail = self.tail and '...{}'.format(self.tail) or ''
+        keyvals = [' %s="%s"' % item for item in self.attrs.items()]
+        attr_str = ''.join(keyvals)
+        return '<%s%s>%s</%s>' % (self.tag, attr_str, text + tail, self.tag)
+
+    def __str__(self):
+        text = self.text or ''
+        tail = self.tail and '...{}'.format(self.tail) or ''
+        keyvals = [' %s="%s"' % item for item in self.attrs.items()]
+        attr_str = ''.join(keyvals)
+        return '<%s%s>%s</%s>' % (self.tag, attr_str, text + tail, self.tag)
+
+    """Easy way to get an element's (direct, not deeply nested) child by name.
+    """
+    def __getitem__(self, name):
+        ch = dict()
+        tags = [c.tag for c in self.children]
+
+        for child in self.children:
+            if tags.count(name) > 1:  # more than 1 child with the same name
+                ch[child.tag] = [c for c in self.children if c.tag == name]
+            else:
+                ch[child.tag] = child
+        # FIXME: perhaps we can improve error messaging by returning
+        #        something other than None
+        default = None
+        return ch.get(name, default)
+
+    def __getattr__(self, name):
+        item = self.__getitem__(name)
+        if item:  # see: __bool__
+            return item
+        else:
+            raise AttributeError
+
+    """Make its length be the length of its children."""
+    def __len__(self):
+        return len(self.children)
+
+    # https://docs.python.org/3/reference/datamodel.html#object.__bool__
+    def __bool__(self):
+        return True
+
+    """Make it iterable, see also ``iter()``"""
+    def __iter__(self):
+        return iter(self.children)
+
+    def iter(self, tag=None):
+        if tag == '*':
+            tag = None
+        if tag is None or self.tag == tag:
+            yield self
+
+        for child in self:
+            yield from child.iter(tag)
+
+    def find(self, tag=None):
+        # returns the first matching element within self where tag == tag
+        try:
+            return tuple(self.iter(tag))[0]
+        except IndexError:
+            return None  # not found
+
+    def findall(self, tag=None):
+        return tuple(self.iter(tag))
+
+    def find_by_path(self, path):
+        path = path.strip('/')
+        targets = path.split('/')
+        found = None
+        for target in targets:
+            for elem in self.iter(target):
+                if target == elem.tag:
+                    found = elem
+                    break
+        return found
+
+    """Make it a tree"""
+    def add_child(self, child):
+        # Works like append for XML ElementTree-s
+        child.parent = self
+        self.children.append(child)
+        return self
+
+    def insert_text(self, content):
+        content = content.strip()
+        if self.text and content:  # if it's already got text, it's a tail.
+            return PressElement(self.tag, attrs=self.attrs, text=self.text,
+                                tail=content)
+        else:
+            return PressElement(self.tag, attrs=self.attrs, text=content)
+
+    def _itertext(self):
+        if self.text:
+            yield self.text
+        for e in self:
+            for s in e._itertext():
+                yield s
+            if e.tail:
+                yield e.tail
+
+    def alltext(self):
+        text = [t for t in self._itertext()]
+        title_as_string = ' '.join(text + [self.tail or '']).strip()
+        return title_as_string
+
+    def child_number(self, pos):
+        try:
+            return self.children[pos - 1]
+        except IndexError:
+            return None
+
+    def attr(self, attr_name):
+        default = None
+        return self.attrs.get(attr_name, default)

--- a/press/parsers/__init__.py
+++ b/press/parsers/__init__.py
@@ -1,2 +1,2 @@
-from .collection import parse_collection_metadata  # noqa: F401
+from .collection import parse_collection_metadata, parse_collxml  # noqa: F401
 from .module import parse_module_metadata  # noqa: F401

--- a/press/parsers/collection.py
+++ b/press/parsers/collection.py
@@ -1,4 +1,5 @@
-from press.models import CollectionMetadata
+from xml import sax
+from press.models import CollectionMetadata, PressElement
 from .common import make_cnx_xpath, make_elm_tree, parse_common_properties
 
 
@@ -23,3 +24,60 @@ def parse_collection_metadata(model):
         props['print_style'] = print_style[0]
 
     return CollectionMetadata(**props)
+
+
+class CollectionXmlHandler(sax.ContentHandler):
+    def __init__(self, root):
+        self.current_node = root
+        self.next_node = None
+
+    def startElementNS(self, name, qname, attrs):
+        uri, localname = name
+
+        # TODO: we could improve this by passing in just the URI and have the
+        #       model map it to a namespace.
+        self.next_node = PressElement(localname,
+                                      self._attrs_no_uri(attrs))
+
+        self.current_node.add_child(self.next_node)
+        self.current_node = self.next_node
+
+    def characters(self, content):
+        # we have to create a new node so that the hash is re-calculated,
+        # see docs for __hash__ method.
+        new_node = self.current_node.insert_text(content)
+        new_node.parent = self.current_node.parent
+        new_node.children = self.current_node.children
+        # the parent needs to contain the new child element for the old one
+        self.current_node.parent.children.pop()
+        self.current_node.parent.children.append(new_node)
+        # and finally...
+        self.current_node = new_node
+
+    def endElementNS(self, name, qname):
+        self.current_node = self.current_node.parent
+
+    def _attrs_no_uri(self, attrs):
+        return {name: value for (uri, name), value in attrs.items()}
+
+
+def parse_collxml(input_collxml):
+    """
+    Given a collxml document, parses the document to a python object
+    where collections and sub-collections (both branching points) contain
+    subcollections and modules (leaf nodes).
+    """
+    tree_root = PressElement('root')
+
+    parser = sax.make_parser()
+    parser.setFeature(sax.handler.feature_namespaces, 1)
+    parser.setContentHandler(CollectionXmlHandler(tree_root))
+
+    # adds the ability to parse an object that comes from the database
+    if isinstance(input_collxml, memoryview):
+        import io
+        input_collxml = io.BytesIO(input_collxml)
+
+    parser.parse(input_collxml)  # parses a file-like object
+
+    return tree_root

--- a/tests/unit/models/test_press_element.py
+++ b/tests/unit/models/test_press_element.py
@@ -1,0 +1,96 @@
+from press.models import PressElement
+
+
+def gen_press_element_tree():
+    collection = PressElement('collection')
+    collection.add_child(PressElement('mod1'))
+    collection.add_child(PressElement('mod2'))
+    collection.add_child(PressElement('mod3'))
+    collection.add_child(PressElement('mod4'))
+    child3 = collection.child_number(3)
+    child3.add_child(PressElement('mod3--1'))
+    child3.add_child(PressElement('mod3--2'))
+    return collection
+
+
+def test_string_representation():
+    attrs = {'some-attr': 'somevalue', 'version': '1.1'}
+    attrs_str = 'some-attr="somevalue" version="1.1"'
+    content = 'Text and... trailing text!'
+    expected = '<sometag %s>%s</sometag>' % (attrs_str, content)
+    element = PressElement('sometag', text='Text and', tail=' trailing text!',
+                           attrs=attrs)
+
+    assert repr(element) == expected
+
+    assert repr(PressElement('tagname')) == '<tagname></tagname>'
+    assert str(PressElement('tagname')) == '<tagname></tagname>'
+    assert str(PressElement('tagname', text='Yes')) == '<tagname>Yes</tagname>'
+
+
+def test_tree_behavior(content_util):
+    """Test that you can insert a child or children
+    """
+    collection = gen_press_element_tree()
+
+    col_children = ['<mod1></mod1>', '<mod2></mod2>', '<mod3></mod3>',
+                    '<mod4></mod4>']
+    mod3_children = ['<mod3--1></mod3--1>', '<mod3--2></mod3--2>']
+    assert [str(c) for c in collection.children] == col_children
+    assert [str(c) for c in mod3_children] == mod3_children
+
+
+def test_iterator_behavior():
+    """You can iterate through the tree depth-first.
+    """
+    actual = gen_press_element_tree()
+
+    expected = ['<collection></collection>',
+                '<mod1></mod1>',
+                '<mod2></mod2>',
+                '<mod3></mod3>',
+                '<mod3--1></mod3--1>', '<mod3--2></mod3--2>',
+                '<mod4></mod4>']
+
+    for actual, ex in zip(actual.iter(), expected):
+        assert str(actual) == ex
+
+
+def test_equality_behavior():
+    """A Node can be compared against another using the == operator
+    (or another as a last resort).
+    """
+    attrs = {'someattribrute': '_the_value_'}
+    a = PressElement('someelement', text='ciao', tail='papaya', attrs=attrs)
+    b = PressElement('someelement', text='ciao', tail='papaya', attrs=attrs)
+
+    # this would fail if we hadn't defined __hash__ and __eq__
+    assert a == b
+
+    """Modules with a different ``document`` attribute do not equal
+    """
+    attrs = {'document': 'm00004'}
+    a = PressElement('md', text='TxT', tail='TaiL', attrs=attrs)
+    attrs = {'document': 'm00005'}
+    b = PressElement('md', text='TxT', tail='TaiL', attrs=attrs)
+    assert a != b
+
+
+def test_objectified_magic():
+    """Test the ability to access a nested element by simply calling an
+    attribute on the tree/element.
+    """
+    title = PressElement('title', text='Collection Title')
+    anothertag = PressElement('anothertag')
+    anothertag.add_child(title)
+    metadata = PressElement('metadata', text='text within md tag')
+    metadata.add_child(anothertag)
+    collection = PressElement('collection')
+    collection.add_child(metadata)
+    """
+    collection
+        => metadata
+            => anothertag
+                => title
+    """
+    assert collection.metadata.anothertag.title.text == 'Collection Title'

--- a/tests/unit/parsers/test_collection.py
+++ b/tests/unit/parsers/test_collection.py
@@ -4,7 +4,17 @@ from litezip import parse_collection
 from litezip.main import COLLECTION_NSMAP
 from lxml import etree
 
-from press.parsers import parse_collection_metadata
+from press.parsers import parse_collection_metadata, parse_collxml
+from press.models import PressElement
+
+
+def test_parse_collxml(content_util):
+    collection, _, _ = content_util.gen_collection()
+    output = parse_collxml(collection.file.open('rb'))
+
+    assert isinstance(output, PressElement)
+    assert len(output.findall()) > 100  # just a smoke test, arbitrary #.
+    assert output.tag == 'root'  # what the root tag is called.
 
 
 def test_parse_collection_metadata(litezip_valid_litezip):


### PR DESCRIPTION
- Add PressElement, a collxml element parsed from collection.xml

  This is used in the collxml parser in the next commit.

- Add a SAX-based collection.xml parser

  This parser will help us determine whether a book needs a major or minor
  rev.

----

Part 2/3 of #190