### PR TITLE
Add ability to detect major / minor rev

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -7,6 +7,7 @@ Change Log
 
 - Undo temporary policy to disallow changes to collection.xml files
 - Create a collection xml parser
+- Add the ability to detect when to major rev and when to minor rev
 
 7.3.0
 -----

--- a/press/legacy_publishing/litezip.py
+++ b/press/legacy_publishing/litezip.py
@@ -61,8 +61,8 @@ def publish_litezip(struct, submission, db_conn):
         except Unchanged:
             pass  # only publish content that has changed.
 
-    any_changes = id_map != {}
-    if any_changes:
+    modules_changed = bool(id_map)
+    if modules_changed:
         # Rebuild the Collection tree from the newly published Modules.
         with collection.file.open('wb') as fb:
             fb.write(etree.tounicode(xml).encode('utf8'))
@@ -71,7 +71,8 @@ def publish_litezip(struct, submission, db_conn):
     metadata = parse_collection_metadata(collection)
     old_id = collection.id
     (id, version), ident = publish_legacy_book(
-        collection, metadata, submission, db_conn)
+        collection, metadata, submission, db_conn,
+        modules_changed=modules_changed)
     id_map[old_id] = (id, version)
 
     return id_map

--- a/press/legacy_publishing/utils.py
+++ b/press/legacy_publishing/utils.py
@@ -8,12 +8,112 @@ from lxml import etree
 from ..utils import convert_version_to_legacy_version, \
     produce_hashes_from_filepath
 
-
 __all__ = (
     'replace_derived_from',
     'replace_id_and_version',
+    'needs_major_rev',
+    'needs_minor_rev',
     'produce_hashes_from_filepath',
 )
+
+
+def needs_major_rev(pre, post):
+    """True if:
+    - Collection title changes (this does not include module title changes)
+    - Collection structure changes (adding, removing, moving)
+    """
+    removed = set(pre.iter('module')) - set(post.iter('module'))
+    added = set(post.iter('module')) - set(pre.iter('module'))
+
+    if len(removed) != 0 or len(added) != 0:
+        return True  # number of modules changed
+
+    if pre.find('title').alltext() != post.find('title').alltext():
+        return True  # collection's title changed
+
+    for this, other in zip(pre.find('content').iter(),
+                           post.find('content').iter()):
+        if this != other:
+            return True  # order changed
+
+    return False
+
+
+def needs_minor_rev(pre, post):
+    """True if:
+    1. Collection or module metadata changes
+        - abstract
+        - subject
+    2. Parameter changes
+    3. Collection or module actor changes
+    4. Collection or module role changes
+    5. Module version changes
+    """
+    if pre.find('abstract') != post.find('abstract'):
+        return True
+    if pre.find('subjectlist').alltext() != post.find('subjectlist').alltext():
+        return True
+
+    params_before = params_as_dict(pre.findall('param'))
+    params_after = params_as_dict(post.findall('param'))
+
+    if params_before != params_after:
+        return True
+
+    actors_before = actors_as_dict(pre.findall('person'))
+    actors_after = actors_as_dict(post.findall('person'))
+
+    if actors_before != actors_after:
+        return True
+
+    roles_before = roles_as_dict(pre.findall('role'))
+    roles_after = roles_as_dict(post.findall('role'))
+
+    if roles_before != roles_after:
+        return True
+
+    pre_versions = versions_as_set(pre.findall('module'))
+    post_versions = versions_as_set(post.findall('module'))
+
+    if pre_versions != post_versions:
+        return True
+
+    return False
+
+
+def params_as_dict(params):
+    params_dict = dict()
+
+    for p in params:
+        k = p.attrs['name']
+        v = p.attrs['value']
+        params_dict[k] = v
+    return params_dict
+
+
+def actors_as_dict(persons):
+    actors_dict = dict()
+
+    for p in persons:
+        actors_dict[p.firstname] = p.firstname.text
+        actors_dict[p.surname] = p.surname.text
+        actors_dict[p.fullname] = p.fullname.text
+    return actors_dict
+
+
+def roles_as_dict(roles):
+    authors_dict = dict()
+
+    for r in roles:
+        for k, v in r.attrs.items():
+            authors_dict[r.attrs['type']] = set(r.text.split(' '))
+    return authors_dict
+
+
+def versions_as_set(modules):
+    return set((m.attr('document'),
+                m.attr('version-at-this-collection-version'))
+               for m in modules)
 
 
 def replace_derived_from(model, derived_from_url):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -603,9 +603,9 @@ class _ContentUtil:
 
     def flatten_collection_tree_to_nodes(self, tree):
         """Given a collection tree, flatten it to end nodes (module items)."""
-        for node in tree['contents']:
-            if 'contents' in node:
-                yield from self.flatten_collection_tree_to_nodes(node)
+        for node in tree:
+            if hasattr(node, 'contents'):
+                yield from self.flatten_collection_tree_to_nodes(node.contents)
             else:
                 yield node
 

--- a/tests/functional/legacy_publishing/test_collection.py
+++ b/tests/functional/legacy_publishing/test_collection.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from dateutil.parser import parse as parse_date
 from litezip.main import COLLECTION_NSMAP
 from sqlalchemy.sql import text
+import pytest
 
 from press.legacy_publishing.collection import (
     publish_legacy_book,
@@ -9,6 +10,7 @@ from press.legacy_publishing.collection import (
 from press.parsers import (
     parse_collection_metadata,
 )
+from press.exceptions import Unchanged
 
 from tests.conftest import GOOGLE_ANALYTICS_CODE
 from tests.helpers import (
@@ -40,7 +42,7 @@ def test_publish_revision_base_case(
     )
     control_metadata = db_engines['common'].execute(stmt).fetchone()
 
-    # Insert a new module ...
+    # Insert a new module (will cause a major version rev!)
     new_module = content_util.gen_module()
     new_module = persist_util.insert_module(new_module)
     # ... remove second element from the tree ...
@@ -68,9 +70,9 @@ def test_publish_revision_base_case(
     )
     result = db_engines['common'].execute(stmt).fetchone()
     assert result.uuid == control_metadata.uuid
-    assert result.major_version == 1
-    assert result.minor_version == 2
-    assert result.version == '1.1'
+    assert result.major_version == 2
+    assert result.minor_version == 1
+    assert result.version == '1.2'
     assert result.abstractid == control_metadata.abstractid
     assert result.created == parse_date(metadata.created)
     assert result.revised == now
@@ -297,9 +299,9 @@ def test_publish_derived(
     )
     result = db_engines['common'].execute(stmt).fetchone()
     assert result.uuid == control_metadata.uuid
-    assert result.major_version == 1
-    assert result.minor_version == 2
-    assert result.version == '1.1'
+    assert result.major_version == 2
+    assert result.minor_version == 1
+    assert result.version == '1.2'
     assert result.abstract == derived_metadata.abstract
     assert result.created == parse_date(derived_metadata.created)
     assert result.revised == now
@@ -371,6 +373,11 @@ def test_publish_revision_with_new_resources(
     # prior to our publication
     control_files = {x.filename: x for x in control_data}
     assert book_cover.filename not in control_files
+
+    # make it publishable
+    with element_tree_from_model(collection) as xml:
+        elem = xml.xpath('//md:title', namespaces=COLLECTION_NSMAP)[0]
+        elem.text = 'a different collection title'
 
     # TARGET
     with db_engines['common'].begin() as conn:
@@ -445,9 +452,14 @@ def test_publish_revision_that_overwrites_existing_resources(
 
     # FIXME: temporarily skipping this check. Re-enable when we add a full
     #        implementation of the collxml diffying code.
-    # assert replaced_file_record.sha1 == book_cover.sha1
+    assert replaced_file_record.sha1 == book_cover.sha1
 
     assert replaced_file_record.file == book_cover.data.read_bytes()
+
+    # make it publishable
+    with element_tree_from_model(collection) as xml:
+        elem = xml.xpath('//md:title', namespaces=COLLECTION_NSMAP)[0]
+        elem.text = 'a different collection title'
 
     # TARGET
     with db_engines['common'].begin() as conn:
@@ -469,3 +481,32 @@ def test_publish_revision_that_overwrites_existing_resources(
     assert files[new_book_cover.filename].sha1 == new_book_cover.sha1
     assert files[new_book_cover.filename].file == \
         new_book_cover.data.read_bytes()
+
+
+def test_publish_with_no_major_or_minor_rev_changes(
+        content_util, persist_util, app, db_engines, db_tables):
+    """MAKING CHANGES other than those which cause a major or minor version rev
+     DO cause Unchanged to be raised.
+    """
+    resources = list([content_util.gen_resource() for x in range(0, 2)])
+    collection, tree, modules = content_util.gen_collection(
+        resources=resources
+    )
+    modules = list([persist_util.insert_module(m) for m in modules])
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+    collection = persist_util.insert_collection(collection)
+    metadata = parse_collection_metadata(collection)
+
+    # TARGET
+    with element_tree_from_model(collection) as xml:
+        elem = xml.xpath('//md:created', namespaces=COLLECTION_NSMAP)[0]
+        elem.text = 'something different'
+
+    with pytest.raises(Unchanged), db_engines['common'].begin() as conn:
+        (id, version), ident = publish_legacy_book(
+            collection,
+            metadata,
+            ('user1', 'test publish',),
+            conn,
+        )

--- a/tests/functional/legacy_publishing/test_litezip.py
+++ b/tests/functional/legacy_publishing/test_litezip.py
@@ -23,6 +23,14 @@ def test_publish_litezip(
     tree.pop(1)
     # ... and append the new module to the tree.
     tree.append(content_util.make_tree_node_from(new_module))
+
+    # Change the module text, to make it publishable.
+    index_cnxml = new_module.file.read_text()
+    start_offset = index_cnxml.find('test document')
+    new_module.file.write_text(index_cnxml[:start_offset] +
+                               'TEST DOCUMENT' +
+                               index_cnxml[start_offset + 13:])
+
     collection, tree, modules = content_util.rebuild_collection(collection,
                                                                 tree)
     struct = tuple([collection, new_module])
@@ -35,9 +43,109 @@ def test_publish_litezip(
         )
 
     expected_id_map = {
+        new_module.id: (new_module.id, (2, None)),
+        collection.id: (collection.id, (2, 1)),
+    }
+    assert expected_id_map == id_map
+
+    # Update the tree to reflect the Module publication above.
+    tree[-1].version_at = '1.2'
+
+    # Check the collection tree for accuracy. (This is not out of scope,
+    # because the collection.xml document needs modified before insertion.)
+    stmt = (
+        text("SELECT tree_to_json_for_legacy("
+             "  m.uuid::text, "
+             "  concat_ws('.', m.major_version, m.minor_version)::text"
+             ")::json "
+             "FROM modules AS m "
+             "WHERE m.moduleid = :moduleid "
+             "AND m.major_version = :major_version "
+             "AND m.minor_version = :minor_version")
+        .bindparams(moduleid=collection.id, major_version=2, minor_version=1))
+    inserted_tree = db_engines['common'].execute(stmt).fetchone()[0]
+    compare_legacy_tree_similarity(inserted_tree['contents'], tree)
+
+
+def test_publish_litezip_collectionxml_only(
+        content_util, persist_util, app, db_engines, db_tables):
+    # Insert initial collection and modules.
+    collection, tree, modules = content_util.gen_collection()
+    modules = list([persist_util.insert_module(m) for m in modules])
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+    collection = persist_util.insert_collection(collection)
+
+    # ... remove second element from the tree ...
+    tree.pop(1)
+
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+    struct = tuple([collection])
+
+    with db_engines['common'].begin() as conn:
+        id_map = publish_litezip(
+            struct,
+            ('user1', 'test publish collection.xml',),
+            conn,
+        )
+
+    expected_id_map = {
+        collection.id: (collection.id, (2, 1)),
+    }
+    assert expected_id_map == id_map
+
+    # Check the collection tree for accuracy. (This is not out of scope,
+    # because the collection.xml document needs modified before insertion.)
+    stmt = (
+        text("SELECT tree_to_json_for_legacy("
+             "  m.uuid::text, "
+             "  concat_ws('.', m.major_version, m.minor_version)::text"
+             ")::json "
+             "FROM modules AS m "
+             "WHERE m.moduleid = :moduleid "
+             "AND m.major_version = :major_version "
+             "AND m.minor_version = :minor_version")
+        .bindparams(moduleid=collection.id, major_version=2, minor_version=1))
+    inserted_tree = db_engines['common'].execute(stmt).fetchone()[0]
+    compare_legacy_tree_similarity(inserted_tree['contents'], tree)
+
+
+def test_publish_litezip_minor_rev(
+        content_util, persist_util, app, db_engines, db_tables):
+    # Insert initial collection and modules.
+    collection, tree, modules = content_util.gen_collection()
+    modules = list([persist_util.insert_module(m) for m in modules])
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+    collection = persist_util.insert_collection(collection)
+
+    # Modify the module text.
+    index_cnxml = modules[0].file.read_text()
+    start_offset = index_cnxml.find('test document')
+    modules[0].file.write_text(index_cnxml[:start_offset] +
+                               'TEST DOCUMENT' +
+                               index_cnxml[start_offset + 13:])
+
+    struct = tuple([collection, modules[0]])
+
+    with db_engines['common'].begin() as conn:
+        id_map = publish_litezip(
+            struct,
+            ('user1', 'test publish module',),
+            conn,
+        )
+
+    expected_id_map = {
+        modules[0].id: (modules[0].id, (2, None)),
         collection.id: (collection.id, (1, 2)),
     }
-    assert id_map == expected_id_map
+    assert expected_id_map == id_map
+
+    # Update the tree to reflect the Module publication above.
+    for node in content_util.flatten_collection_tree_to_nodes(tree):
+        if getattr(node, 'id', None) == modules[0].id:
+            node.version_at = '1.2'
 
     # Check the collection tree for accuracy. (This is not out of scope,
     # because the collection.xml document needs modified before insertion.)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -74,3 +74,12 @@ def retryable_timeout_request_mock_callback(func):
     wrapper.tries = {}
 
     return wrapper
+
+
+def gen_element(namespace, tag, text, tail=None):
+    from litezip.main import COLLECTION_NSMAP
+    elem = etree.Element(
+        '{{{}}}{}'.format(COLLECTION_NSMAP[namespace], tag),
+        nsmap=COLLECTION_NSMAP)
+    elem.text = text
+    return elem

--- a/tests/unit/legacy_publishing/test_utils.py
+++ b/tests/unit/legacy_publishing/test_utils.py
@@ -1,7 +1,304 @@
+from lxml import etree
+from litezip.main import COLLECTION_NSMAP
 from press.legacy_publishing.utils import (
     replace_derived_from,
     replace_id_and_version,
+    needs_major_rev,
+    needs_minor_rev,
 )
+from press.parsers import parse_collxml
+from tests.helpers import gen_element, element_tree_from_model
+
+
+class TestMajorVersionRev():
+    def test_when_collection_title_changes(self, content_util):
+        collection, tree, modules = content_util.gen_collection()
+        with collection.file.open('rb') as fb:
+            xml = etree.parse(fb)
+        elem = xml.xpath('//md:title', namespaces=COLLECTION_NSMAP)[0]
+        expected_title = 'Some other, different title'
+        assert elem.text != expected_title
+
+        elem.text = expected_title  # change the collection's title
+
+        file_copy = str(collection.file)[:-4] + '_copy.xml'
+        with open(file_copy, 'wb') as fb:
+            # Write the modified xml to a different file
+            fb.write(etree.tostring(xml))
+
+        with collection.file.open('rb') as f, open(file_copy, 'rb') as cp:
+            tree_before = parse_collxml(f)
+            tree_after = parse_collxml(cp)
+            assert needs_major_rev(tree_before, tree_after)
+
+        # and just to be sure, this should be false:
+        with collection.file.open('rb') as original:
+            tree = same_tree = parse_collxml(original)
+            assert needs_major_rev(tree, same_tree) is False
+
+    def test_when_collection_structure_changes(self, content_util):
+        # TODO: assert ONLY content tree (modules) reordering cause major rev
+        collection, tree, _ = content_util.gen_collection()
+
+        with collection.file.open('rb') as f:
+            tree_before = parse_collxml(f)
+
+        # move the first element to location index 3 in the tree
+        element = tree.pop(0)
+        tree.insert(2, element)
+
+        # generate a new collection.xml file with the reaaranged tree
+        coll_after, _, _ = content_util.rebuild_collection(collection, tree)
+
+        with coll_after.file.open('rb') as f:
+            tree_after = parse_collxml(f)
+
+        assert needs_major_rev(tree_before, tree_after)
+
+    def test_when_adding_a_new_module(self, content_util):
+        collection, tree, _ = content_util.gen_collection()
+
+        with collection.file.open('rb') as f:
+            tree_before = parse_collxml(f)
+
+        # add a new module
+        new_module = content_util.gen_module(relative_to=collection)
+        tree.append(content_util.make_tree_node_from(new_module))
+
+        # generate a new collection.xml file with the extra module
+        coll_after, _, _ = content_util.rebuild_collection(collection, tree)
+
+        with coll_after.file.open('rb') as f:
+            tree_after = parse_collxml(f)
+
+        assert needs_major_rev(tree_before, tree_after)
+
+    def test_when_removing_a_module(self, content_util):
+        collection, tree, _ = content_util.gen_collection()
+
+        with collection.file.open('rb') as f:
+            tree_before = parse_collxml(f)
+
+        # remove a module (or subcollection which is a set of modules)
+        tree.pop(1)
+
+        coll_after, _, _ = content_util.rebuild_collection(collection, tree)
+
+        with coll_after.file.open('rb') as f:
+            tree_after = parse_collxml(f)
+
+        assert needs_major_rev(tree_before, tree_after)
+        mods_len_before = len(tuple(tree_before.iter('module')))
+        mods_len_after = len(tuple(tree_after.iter('module')))
+        assert mods_len_before > mods_len_after
+
+
+class TestMinorVersionRev():
+    def test_when_md_abstr_changes(self, content_util):
+        # eg: abstract or subject is updated
+        collection, tree, _ = content_util.gen_collection()
+        with collection.file.open('rb') as f, collection.file.open('rb') as f2:
+            tree_before = parse_collxml(f)
+            xml = etree.parse(f2)
+
+        """change the abstract"""
+        abstract = xml.xpath('//md:abstract', namespaces=COLLECTION_NSMAP)[0]
+        abstract.text = 'A different abstract'
+
+        # write it to a different file
+        file_abstr_changed = '{}_abstr.xml'.format(str(collection.file)[:-4])
+        with open(file_abstr_changed, 'wb') as f:
+            f.write(etree.tostring(xml))
+
+        with open(file_abstr_changed, 'rb') as f:
+            tree_after = parse_collxml(f)
+
+        assert needs_minor_rev(tree_before, tree_after)
+
+    def test_when_md_subj_changes(self, content_util):
+        """change the subject(s)"""
+        collection, tree, _ = content_util.gen_collection()
+        with collection.file.open('rb') as f, collection.file.open('rb') as f2:
+            tree_before = parse_collxml(f)
+            xml = etree.parse(f2)
+
+        subj = xml.xpath('//md:subject', namespaces=COLLECTION_NSMAP)[0]
+        original_subj = subj.text
+        subj.text = 'Some other subject'
+
+        file_subj_changed = '{}_subj.xml'.format(str(collection.file)[:-4])
+        with open(file_subj_changed, 'wb') as f:
+            f.write(etree.tostring(xml))
+
+        with open(file_subj_changed, 'rb') as f:
+            tree_after = parse_collxml(f)
+
+        assert needs_minor_rev(tree_before, tree_after)
+
+        # adding a new subject also works
+        # but revert the xml object to original subject(s) first
+        subj.text = original_subj
+        assert subj.text != 'Some other subject'
+
+        subjs = xml.xpath('//md:subjectlist', namespaces=COLLECTION_NSMAP)[0]
+        new_subject = etree.Element(
+            '{{{}}}subjectlist'.format(COLLECTION_NSMAP['md']),
+            nsmap=COLLECTION_NSMAP)
+        new_subject.text = 'A new subject'
+        subjs.append(new_subject)
+
+        file_new_subj = '{}_new_subj.xml'.format(str(collection.file)[:-4])
+        with open(file_new_subj, 'wb') as f:
+            f.write(etree.tostring(xml))
+
+        with open(file_new_subj, 'rb') as f:
+            tree_after = parse_collxml(f)
+        # assert 'Some other subject' in
+        assert needs_minor_rev(tree_before, tree_after)
+
+    def test_when_md_params_change(self, content_util):
+        """change params"""
+        collection, tree, _ = content_util.gen_collection()
+        with collection.file.open('rb') as f, collection.file.open('rb') as f2:
+            tree_before = parse_collxml(f)
+            xml = etree.parse(f2)
+
+        # change an existing param's value
+        params = xml.xpath('//col:parameters', namespaces=COLLECTION_NSMAP)[0]
+        first_param = params[0]
+        first_param.attrib['value'] = 'A different value'
+
+        file_changed_param = '{}_ch_prm.xml'.format(str(collection.file)[:-4])
+        with open(file_changed_param, 'wb') as f:
+            f.write(etree.tostring(xml))
+
+        with open(file_changed_param, 'rb') as f:
+            tree_after = parse_collxml(f)
+
+        assert needs_minor_rev(tree_before, tree_after)
+
+        """Test that changing the order of the params doesn't matter."""
+        collection, tree, _ = content_util.gen_collection()
+        tree_before = parse_collxml(collection.file.open('rb'))
+
+        with element_tree_from_model(collection) as xml:
+            # make the last param become the first param
+            params = xml.xpath('//col:parameters',
+                               namespaces=COLLECTION_NSMAP)[0]
+            # ... but first, essentially make a copy of the last param
+            last_param = params[-1]
+            new_param_obj = etree.Element(
+                '{{{}}}param'.format(COLLECTION_NSMAP['col']),
+                nsmap=COLLECTION_NSMAP, name=last_param.attrib['name'],
+                value=last_param.attrib['value'])
+            params.insert(0, new_param_obj)
+            params.remove(last_param)
+
+        tree_after = parse_collxml(collection.file.open('rb'))
+
+        assert needs_minor_rev(tree_before, tree_after) is False
+
+    def test_when_md_actors_change(self, content_util):
+        """Change actors"""
+        collection, tree, _ = content_util.gen_collection()
+        with collection.file.open('rb') as f, collection.file.open('rb') as f2:
+            tree_before = parse_collxml(f)
+            xml = etree.parse(f2)
+
+        firstname = xml.xpath('//md:firstname', namespaces=COLLECTION_NSMAP)[0]
+        firstname.text = 'Elon'
+        surname = xml.xpath('//md:surname', namespaces=COLLECTION_NSMAP)[0]
+        surname.text = 'Musk'
+        fullname = xml.xpath('//md:fullname', namespaces=COLLECTION_NSMAP)[0]
+        fullname.text = 'Elon Musk'
+
+        actor_changed = '{}_ch_act_order.xml'.format(str(collection.file)[:-4])
+        with open(actor_changed, 'wb') as f:
+            f.write(etree.tostring(xml))
+
+        with open(actor_changed, 'rb') as f:
+            tree_after = parse_collxml(f)
+
+        assert needs_minor_rev(tree_before, tree_after)
+
+        """Test that changing the order of the actors doesn't matter."""
+        collection, tree, _ = content_util.gen_collection()
+        with collection.file.open('rb') as f, collection.file.open('rb') as f2:
+            tree_before = parse_collxml(f)
+            xml = etree.parse(f2)
+
+        # make the last actor become the first actor
+        actors = xml.xpath('//md:actors', namespaces=COLLECTION_NSMAP)[0]
+        assert len(actors) == 1  # only one child, so only one actor.
+        # ... but first, essentially make a copy of the last actor
+        new_actor_obj = gen_element('md', 'person', None)
+        new_actor_obj.insert(0, gen_element('md', 'firstname', 'Elon'))
+        new_actor_obj.insert(1, gen_element('md', 'surname', 'Musk'))
+        new_actor_obj.insert(2, gen_element('md', 'fullname', 'Elon Musk'))
+        actors.insert(1, new_actor_obj)  # insert in second place
+        assert len(actors) == 2
+
+        # NOW change the order
+        actors = xml.xpath('//md:actors', namespaces=COLLECTION_NSMAP)[0]
+        last_actor = actors[1]
+        actors.insert(0, last_actor)
+        actors.remove(last_actor)
+
+        file_acto_order = '{}_ch_actorr.xml'.format(str(collection.file)[:-4])
+        with open(file_acto_order, 'wb') as f:
+            f.write(etree.tostring(xml))
+
+        with open(file_acto_order, 'rb') as f:
+            tree_after = parse_collxml(f)
+
+        assert needs_minor_rev(tree_before, tree_after) is False
+
+    def test_when_md_roles_change(self, content_util):
+        """Change roles"""
+        collection, tree, _ = content_util.gen_collection()
+        with collection.file.open('rb') as f, collection.file.open('rb') as f2:
+            tree_before = parse_collxml(f)
+            xml = etree.parse(f2)
+
+        author = xml.xpath('//md:role[@type="author"]',
+                           namespaces=COLLECTION_NSMAP)[0]
+        author.text = 'A different author'
+        maintainer = xml.xpath('//md:role[@type="maintainer"]',
+                               namespaces=COLLECTION_NSMAP)[0]
+        maintainer.text = 'A different maintainer'
+        licensor = xml.xpath('//md:role[@type="licensor"]',
+                             namespaces=COLLECTION_NSMAP)[0]
+        licensor.text = 'A different licensor'
+
+        file_author_ch = '{}_ch_auth.xml'.format(str(collection.file)[:-4])
+        with open(file_author_ch, 'wb') as f:
+            f.write(etree.tostring(xml))
+
+        with open(file_author_ch, 'rb') as f:
+            tree_after = parse_collxml(f)
+
+        assert needs_minor_rev(tree_before, tree_after)
+
+        """Test that the order of roles (per type) don't matter"""
+        # Just change the authors, not maintainer or licensor.
+        collection, tree, _ = content_util.gen_collection()
+        with collection.file.open('rb') as f, collection.file.open('rb') as f2:
+            tree_before = parse_collxml(f)
+            xml = etree.parse(f2)
+
+        authors = xml.xpath('//md:role[@type="author"]',
+                            namespaces=COLLECTION_NSMAP)[0]
+        authors_list = authors.text.split(' ')
+        authors.text = '{} {}'.format(authors_list[1], authors_list[0])
+
+        fname_after = '{}_ch_auth_order.xml'.format(str(collection.file)[:-4])
+        with open(fname_after, 'wb') as f:
+            f.write(etree.tostring(xml))
+
+        with open(fname_after, 'rb') as f:
+            tree_after = parse_collxml(f)
+
+        assert needs_minor_rev(tree_before, tree_after) is False
 
 
 def test_replace_id_and_version(content_util):


### PR DESCRIPTION
- Add need_major_rev, need_minor_rev util functions

  Add util functions to determine whether the book needs a major or minor
  rev using the collxml parser.

- Add ability to detect major / minor rev

  With the collxml parser, we can now correctly detect when books should
  get a major / minor rev.

---

Part 3/3 of #190