### PR TITLE
Fix intermittent test failures when no rev-ing changes

### DIFF
--- a/press/legacy_publishing/utils.py
+++ b/press/legacy_publishing/utils.py
@@ -31,8 +31,8 @@ def needs_major_rev(pre, post):
     if pre.find('title').alltext() != post.find('title').alltext():
         return True  # collection's title changed
 
-    for this, other in zip(pre.find('content').iter(),
-                           post.find('content').iter()):
+    for this, other in zip(pre.find('content').iter('module'),
+                           post.find('content').iter('module')):
         if this != other:
             return True  # order changed
 


### PR DESCRIPTION
(Attempts to) solve https://github.com/openstax/cnx/issues/325

The tests seem to be passing every time now with the given changes. I suspect the problem could've been in this line: `pre.find('content').iter()`. I changed it to `pre.find('content').iter('module')`.

Before, I suspect it was looking at the ordering and text content of the modules' titles when it was supposed to only look at the ordering of the `module`s.

I don't know what else to do about this issue, too. So, if we can go ahead and merge these changes for now. Then we can revisit if necessary.