### PR TITLE
Fix "fixture db_tables called directly" in tests

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,5 +8,5 @@ Sphinx==2.2.0
 #       These changes have been submitted upstream (unaguil/sphinx-swaggerdoc).
 ##sphinx-swaggerdoc[yaml]
 -e git+https://github.com/pumazi/sphinx-swaggerdoc.git@for-use#egg=sphinx-swaggerdoc
-PyYAML==3.13
+PyYAML==5.1.2
 # /FIXME

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,7 +2,7 @@
 -r ./main.txt
 
 # Make sure to run `make docs` when this is updated to verify the build.
-Sphinx==1.8.4
+Sphinx==2.2.0
 
 # FIXME Pointing at a personal branch with specific changes.
 #       These changes have been submitted upstream (unaguil/sphinx-swaggerdoc).

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,3 +1,3 @@
 # The project's lint dependencies...
 doc8==0.8.0
-flake8==3.7.6
+flake8==3.7.8

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,6 +1,6 @@
 # The project's dependencies...
 
-amqp==2.4.1
+amqp==2.5.1
 
 billiard==3.5.0.5
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -20,7 +20,7 @@ cnx-litezip==1.6.0
 
 cnxml==3.0.1
 
-hupper==1.4.2
+hupper==1.8.1
 
 idna==2.7
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -66,7 +66,7 @@ simplejson==3.16.0
 
 six==1.12.0
 
-SQLAlchemy==1.2.18
+SQLAlchemy==1.3.8
 
 structlog==19.1.0
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -2,7 +2,7 @@
 
 amqp==2.5.1
 
-billiard==3.5.0.5
+billiard==3.6.1.0
 
 bravado-core==5.10.1
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -26,7 +26,7 @@ idna==2.8
 
 jsonref==0.2
 
-jsonschema==2.6.0
+jsonschema==3.0.2
 
 kombu==4.2.2.post1
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -60,7 +60,7 @@ requests==2.22.0
 
 rhaptos.cnxmlutils==1.7.3
 
-sentry-sdk==0.7.2
+sentry-sdk==0.12.0
 
 simplejson==3.16.0
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -74,7 +74,7 @@ swagger-spec-validator==2.4.3
 
 translationstring==1.3
 
-urllib3==1.24.1
+urllib3==1.25.3
 
 venusian==1.2.0
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -30,7 +30,7 @@ jsonschema==3.0.2
 
 kombu==4.6.4
 
-lxml==4.3.0
+lxml==4.4.1
 
 msgpack-python==0.5.6
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -50,7 +50,7 @@ python-dateutil==2.8.0
 
 python-magic==0.4.15
 
-pytz==2018.9
+pytz==2019.2
 
 PyYAML==5.1.2
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -14,7 +14,7 @@ chardet==3.0.4
 
 # If this pinning changes, remember to also change the pinning of the
 # cnx-db docker container image.
-cnx-db==2.7.0
+cnx-db==3.5.1
 
 cnx-litezip==1.6.0
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -38,7 +38,7 @@ PasteDeploy==2.0.1
 
 plaster==1.0
 
-plaster-pastedeploy==0.6
+plaster-pastedeploy==0.7
 
 psycopg2==2.7.7
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -28,7 +28,7 @@ jsonref==0.2
 
 jsonschema==3.0.2
 
-kombu==4.2.2.post1
+kombu==4.6.4
 
 lxml==4.3.0
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -22,7 +22,7 @@ cnxml==3.0.1
 
 hupper==1.8.1
 
-idna==2.7
+idna==2.8
 
 jsonref==0.2
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -14,7 +14,7 @@ chardet==3.0.4
 
 # If this pinning changes, remember to also change the pinning of the
 # cnx-db docker container image.
-cnx-db==3.5.1
+cnx-db==3.5.2
 
 cnx-litezip==1.6.0
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -42,7 +42,7 @@ plaster-pastedeploy==0.7
 
 psycopg2==2.8.3
 
-pyramid==1.10.2
+pyramid==1.10.4
 
 pyramid-swagger==2.6.2
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -52,7 +52,7 @@ python-magic==0.4.15
 
 pytz==2018.9
 
-PyYAML==3.13
+PyYAML==5.1.2
 
 repoze.lru==0.7
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -78,7 +78,7 @@ urllib3==1.25.3
 
 venusian==1.2.0
 
-vine==1.2.0
+vine==1.3.0
 
 WebOb==1.8.5
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -4,7 +4,7 @@ amqp==2.5.1
 
 billiard==3.6.1.0
 
-bravado-core==5.10.1
+bravado-core==5.13.2
 
 celery==4.2.1
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -56,7 +56,7 @@ PyYAML==5.1.2
 
 repoze.lru==0.7
 
-requests==2.21.0
+requests==2.22.0
 
 rhaptos.cnxmlutils==1.3.3
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -58,7 +58,7 @@ repoze.lru==0.7
 
 requests==2.22.0
 
-rhaptos.cnxmlutils==1.3.3
+rhaptos.cnxmlutils==1.7.3
 
 sentry-sdk==0.7.2
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -18,7 +18,7 @@ cnx-db==3.5.1
 
 cnx-litezip==1.6.0
 
-cnxml==2.2.0
+cnxml==3.0.1
 
 hupper==1.4.2
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -40,7 +40,7 @@ plaster==1.0
 
 plaster-pastedeploy==0.7
 
-psycopg2==2.7.7
+psycopg2==2.8.3
 
 pyramid==1.10.2
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -8,7 +8,7 @@ bravado-core==5.13.2
 
 celery==4.3.0
 
-certifi==2018.11.29
+certifi==2019.9.11
 
 chardet==3.0.4
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -44,7 +44,7 @@ psycopg2==2.8.3
 
 pyramid==1.10.4
 
-pyramid-swagger==2.6.2
+pyramid-swagger==2.7.0
 
 python-dateutil==2.8.0
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -6,7 +6,7 @@ billiard==3.6.1.0
 
 bravado-core==5.13.2
 
-celery==4.2.1
+celery==4.3.0
 
 certifi==2018.11.29
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,7 +17,7 @@ MarkupSafe==1.1.1
 
 more-itertools==7.2.0
 
-pillow==5.4.1
+pillow==6.1.0
 
 pluggy==0.8.1
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,7 +13,7 @@ idna==2.8
 
 Jinja2==2.10.1
 
-MarkupSafe==1.1.0
+MarkupSafe==1.1.1
 
 more-itertools==6.0.0
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -41,7 +41,7 @@ six==1.12.0
 
 urllib3==1.25.3
 
-waitress==1.2.1
+waitress==1.3.1
 
 WebOb==1.8.5
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -31,7 +31,7 @@ pytest-cov==2.7.1
 
 python-dateutil==2.8.0
 
-recordclass==0.9
+recordclass==0.12.0.1
 
 requests==2.22.0
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,7 +9,7 @@ chardet==3.0.4
 
 coverage==4.5.2
 
-idna==2.7
+idna==2.8
 
 Jinja2==2.10
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -27,7 +27,7 @@ py==1.8.0
 
 pytest==4.0.2
 
-pytest-cov==2.6.1
+pytest-cov==2.7.1
 
 python-dateutil==2.8.0
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,7 +3,7 @@
 
 beautifulsoup4==4.7.1
 
-certifi==2018.11.29
+certifi==2019.9.11
 
 chardet==3.0.4
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,7 +7,7 @@ certifi==2019.9.11
 
 chardet==3.0.4
 
-coverage==4.5.2
+coverage==4.5.4
 
 idna==2.8
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -33,7 +33,7 @@ python-dateutil==2.8.0
 
 recordclass==0.9
 
-requests==2.21.0
+requests==2.22.0
 
 requests-mock==1.5.2
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,7 @@ more-itertools==7.2.0
 
 pillow==6.1.0
 
-pluggy==0.8.1
+pluggy==0.13.0
 
 pretend==1.0.9
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -45,4 +45,4 @@ waitress==1.3.1
 
 WebOb==1.8.5
 
-WebTest==2.0.32
+WebTest==2.0.33

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -23,7 +23,7 @@ pluggy==0.13.0
 
 pretend==1.0.9
 
-py==1.7.0
+py==1.8.0
 
 pytest==4.0.2
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ coverage==4.5.4
 
 idna==2.8
 
-Jinja2==2.10
+Jinja2==2.10.1
 
 MarkupSafe==1.1.0
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -39,7 +39,7 @@ requests-mock==1.5.2
 
 six==1.12.0
 
-urllib3==1.24.1
+urllib3==1.25.3
 
 waitress==1.2.1
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -25,7 +25,7 @@ pretend==1.0.9
 
 py==1.8.0
 
-pytest==4.0.2
+pytest==5.1.2
 
 pytest-cov==2.7.1
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -35,7 +35,7 @@ recordclass==0.12.0.1
 
 requests==2.22.0
 
-requests-mock==1.5.2
+requests-mock==1.7.0
 
 six==1.12.0
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,7 +15,7 @@ Jinja2==2.10.1
 
 MarkupSafe==1.1.1
 
-more-itertools==6.0.0
+more-itertools==7.2.0
 
 pillow==5.4.1
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 # The project's testing dependencies...
 -r ./main.txt
 
-beautifulsoup4==4.7.1
+beautifulsoup4==4.8.0
 
 certifi==2019.9.11
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import pathlib
 import random
 import shutil
 import tempfile
-import warnings
 import zipfile
 from copy import copy, deepcopy
 
@@ -129,13 +128,7 @@ GOOGLE_ANALYTICS_CODE = 'abc123'
 @pytest.fixture(scope='session')
 def db_tables_session_scope(db_engines):
     from cnxdb.contrib.pytest import db_tables
-    with warnings.catch_warnings():
-        # FIXME: This suppresses the warning for now...
-        #        RemovedInPytest4Warning: Fixture "db_tables" called directly.
-        #        Fixtures are not meant to be called directly, are created
-        #        automatically when test functions request them as parameters.
-        warnings.simplefilter('ignore')
-        tables = db_tables(db_engines)
+    tables = db_tables(db_engines)
     return tables
 
 


### PR DESCRIPTION
In the pytest 4.1.0 changelog:

> Calling fixtures directly is now always an error instead of a warning.

This is the error on travis:

```
______________ ERROR at setup of test_publish_revision_base_case _______________
Fixture "db_tables" called directly. Fixtures are not meant to be called directly,
but are created automatically when test functions request them as parameters.
See https://docs.pytest.org/en/latest/fixture.html for more information about fixtures, and
https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly about how to update your code.
```

One of the solutions suggested by pytest is to separate the function
that has the fixture decorator and the function that returns the
fixture.  This has been changed in cnx-db so the `db_tables` function
can be imported in cnx-press and elsewhere.

---

This PR includes all the updates from pyup-bot weekly updates #462

The last :skull: commit should be removed before merging.

See also openstax/cnx-db#191.